### PR TITLE
Parse phoneNumber before the validation

### DIFF
--- a/lib/phone-type-parser.js
+++ b/lib/phone-type-parser.js
@@ -1,0 +1,7 @@
+
+module.exports = function(phoneNumber) {
+  return {
+    phone: phoneNumber.phone.toString(),
+    country: phoneNumber.country.toUpperCase()
+  };
+};

--- a/lib/phonelib.js
+++ b/lib/phonelib.js
@@ -1,10 +1,13 @@
 var PNF = require('google-libphonenumber').PhoneNumberFormat;
 var phoneUtil = require('google-libphonenumber').PhoneNumberUtil.getInstance();
+var phoneTypeParser = require('./phone-type-parser');
 
 module.exports.isValid = function (phoneNumber, callback) {
 
   var formattedNumber = {};
   var phone = null;
+
+  phoneNumber = phoneTypeParser(phoneNumber);
 
   try {
     phone = phoneUtil.parse(phoneNumber.phone, phoneNumber.country);

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
   "author": "Gepser Hoil",
   "license": "MIT",
   "devDependencies": {
-    "code": "^3.0.2",
-    "jshint": "^2.9.3",
-    "lab": "^11.0.1"
+    "code": "^1.5.0",
+    "jshint": "^2.8.0",
+    "lab": "^5.15.1"
   },
   "dependencies": {
     "google-libphonenumber": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -20,11 +20,11 @@
   "author": "Gepser Hoil",
   "license": "MIT",
   "devDependencies": {
-    "code": "^1.5.0",
-    "jshint": "^2.8.0",
-    "lab": "^5.15.1"
+    "code": "^3.0.2",
+    "jshint": "^2.9.3",
+    "lab": "^11.0.1"
   },
   "dependencies": {
-    "google-libphonenumber": "^1.0.4"
+    "google-libphonenumber": "^1.1.0"
   }
 }


### PR DESCRIPTION
`phonelib` needs to parse the `phone`'s type before start the validation, otherwise, the event will fail even if the `phone` is valid.
